### PR TITLE
Calculate training count as 1.5 hours per day

### DIFF
--- a/src/pages/apps/record/index.astro
+++ b/src/pages/apps/record/index.astro
@@ -34,7 +34,12 @@ const activityFromPreviousGrade = await userActivity({
 });
 const grade = userProfile.grade;
 const nextGrade = timeForNextGrade(grade);
-const needToNextGrade = nextGrade - activityFromPreviousGrade.length;
+const needToNextGrade =
+    nextGrade -
+    activityFromPreviousGrade
+        .map((act) => act.period)
+        .reduce((a, b) => a + b, 0) /
+        1.5;
 
 if (Astro.request.method == "POST") {
     let data = await Astro.request.formData();


### PR DESCRIPTION
Adjust the training count calculation to consider 1.5 hours as equivalent to one day, improving usability for events like training camps.

Fixes #7