### PR TITLE
Set input field step to 0.5 in record edit screen

### DIFF
--- a/src/pages/apps/record/edit/[id].astro
+++ b/src/pages/apps/record/edit/[id].astro
@@ -55,6 +55,7 @@ if (Astro.request.method === "POST") {
             id="period"
             name="period"
             value={activityData.period}
+            step="0.5"
             required
         />
         <button type="submit" class="submit-btn">更新</button>


### PR DESCRIPTION
The input field for the period in the record edit screen now has a step value of 0.5, ensuring proper input increments.

Fixes #5