### PR TITLE
#18 管理ルート保護を追加し、AccountUi コンポーネントをリファクタリング

### DIFF
--- a/src/components/ui/account-ui.astro
+++ b/src/components/ui/account-ui.astro
@@ -1,31 +1,12 @@
 ---
-import type { Role } from "@/src/class";
+interface Props {
+    apps: { name: string; path: string; desc: string }[];
+}
+
+const { apps } = Astro.props;
+
 import Modal from "./modal.astro";
 import ThemeToggle from "./ThemeToggle.astro";
-import { APPS } from "@/src/const";
-
-import { getProfile, getRole } from "@/src/lib/query/profile";
-
-const user = await Astro.locals.currentUser();
-
-if (!user) {
-    return Astro.redirect("/sign-in");
-}
-
-const userProfile = await getProfile({ userId: user.id });
-if (userProfile instanceof Response) {
-    return userProfile;
-}
-
-const role = (await getRole({ userId: user.id })) as Role;
-
-if (role.isManagement() && !APPS.some((app) => app.name === "管理者メニュー")) {
-    APPS.push({
-        name: "管理者メニュー",
-        path: "/admin",
-        desc: "管理者メニューに移動します。",
-    });
-}
 
 import {
     SignedIn,
@@ -61,7 +42,7 @@ import {
             </div>
             <hr />
             {
-                APPS.map((app) => (
+                apps.map((app) => (
                     <div class="account_button, link">
                         <a href={app.path}>{app.name}</a>
                     </div>

--- a/src/layouts/auth-layout.astro
+++ b/src/layouts/auth-layout.astro
@@ -8,6 +8,7 @@ import "@/src/styles/global.css";
 import { APP_NAME } from "@/src/const";
 import { getRole } from "@/src/lib/query/profile";
 import type { Role } from "@/src/class";
+import { APPS } from "@/src/const";
 
 /** Main menu items */
 let textLinks: { label: string; href: string }[] = [
@@ -32,6 +33,14 @@ interface Props {
 
 const homelink = "/dashboard";
 const { title } = Astro.props;
+
+if (role.isManagement() && !APPS.some((app) => app.name === "管理者メニュー")) {
+    APPS.push({
+        name: "管理者メニュー",
+        path: "/admin",
+        desc: "管理者メニューに移動します。",
+    });
+}
 ---
 
 <Baselayout pagename=`${APP_NAME} - ${title}`>
@@ -88,7 +97,7 @@ const { title } = Astro.props;
                 </nav>
             )
         }
-        <AccountUi />
+        <AccountUi apps={APPS} />
     </header>
     <div class="container">
         <main>

--- a/src/layouts/non-auth-layout.astro
+++ b/src/layouts/non-auth-layout.astro
@@ -2,7 +2,7 @@
 import Baselayout from "./baselayout.astro";
 import Footer from "@/src/components/root/footer.astro";
 import Modal from "@/src/components/ui/modal.astro";
-import ThemeToggle from "@/src/components/ui/ThemeToggle.astro";
+import AccountUi from "@/src/components/ui/account-ui.astro";
 const textLinks: { label: string; href: string }[] = [];
 
 import { APPS } from "@/src/const";
@@ -69,30 +69,7 @@ const { title } = Astro.props;
                 </nav>
             )
         }
-        <Modal position="right" icon="  ⵗ  ">
-            <div class="account_prof_name">
-                <a href="/signin">
-                    <span>未ログイン</span>
-                </a>
-            </div>
-            <hr />
-            <div class="account_prof">
-                {
-                    APPS.map((app) => (
-                        <div class="account_button, link">
-                            <a href={app.path}>{app.name}</a>
-                        </div>
-                    ))
-                }
-            </div>
-            <hr />
-            <div
-                style="display: flex; flex-direction: row; align-items: center; justify-content: space-between; align-content: center;"
-            >
-                <span>ダークモード</span>
-                <ThemeToggle />
-            </div>
-        </Modal>
+        <AccountUi apps={APPS} />
     </header>
     <div class="container">
         <main>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ const isProtectedRoute = createRouteMatcher([
     "/dashboard(.*)",
     "/app(.*)",
     "/account(.*)",
+    "/admin(.*)",
 ]);
 
 const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
@@ -21,6 +22,12 @@ export const onRequest = clerkMiddleware((auth, context) => {
         profile.getProfile({ userId: userId }).then((userProfile) => {
             if (userProfile instanceof Response) {
                 return userProfile;
+            }
+            if (
+                Role.fromString(userProfile.role)?.isManagement() &&
+                isAdminRoute(context.request)
+            ) {
+                context.redirect("/dashboard");
             }
         });
     }


### PR DESCRIPTION
Implement route protection for the admin area, redirecting non-admin users to the dashboard. Refactor the AccountUi component to accept an application list, streamlining the addition of the admin menu logic.