### PR TITLE
プルリクエストがマージされたときにのみデプロイをトリガーするように、デプロイおよびプレビューのワークフローを更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,15 @@
 name: Deploy to Cloudflare Pages
 
 on:
-    push:
-        branches: [master]
-    workflow_dispatch:
+    pull_request:
+        types:
+          - closed
+        branches:
+          - 'master'
 
 jobs:
     deploy:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         environment: prod
         name: Deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,12 +1,14 @@
 name: Preview on Cloudflare Pages
 
 on:
-    push:
-        branches-ignore: [master]
-    workflow_dispatch:
-
+    pull_request:
+        types:
+          - closed
+        branches:
+          - 'preview'
 jobs:
     deploy:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         environment: preview
         name: Deploy


### PR DESCRIPTION
この pull requestでは、プッシュ イベントではなく、pull request がマージされたときにのみデプロイをトリガーするようにデプロイ ワークフローを変更します. この変更により、Cloudflare Pagesへのデプロイは、プルリクエストが閉じられてマージされた後にのみ行われるようになります。