### PR TITLE
Change preview deployment trigger to push event

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,15 @@
 name: Deploy to Cloudflare Pages
 
 on:
-    push:
-        branches: [master]
-    workflow_dispatch:
+    pull_request:
+        types:
+          - closed
+        branches:
+          - 'master'
 
 jobs:
     deploy:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         environment: prod
         name: Deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,12 +1,14 @@
 name: Preview on Cloudflare Pages
 
 on:
-    push:
-        branches-ignore: [master]
-    workflow_dispatch:
-
+    pull_request:
+        types:
+          - closed
+        branches:
+          - 'preview'
 jobs:
     deploy:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         environment: preview
         name: Deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,11 +1,9 @@
 name: Preview on Cloudflare Pages
 
 on:
-    pull_request:
-        types:
-          - closed
-        branches:
-          - 'preview'
+  push:
+    branches: [preview]
+
 jobs:
     deploy:
         if: github.event.pull_request.merged == true


### PR DESCRIPTION
Modify the deployment trigger for preview on Cloudflare Pages to activate on push events to the 'preview' branch instead of closed pull requests.