### PR TITLE
月初と月末の時間を設定して、ユーザー活動の取得範囲を調整

### DIFF
--- a/src/pages/apps/record/index.astro
+++ b/src/pages/apps/record/index.astro
@@ -22,7 +22,9 @@ if (userProfile instanceof Response) {
 
 const now = new Date();
 const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+startOfMonth.setHours(0, 0, 0, 0);
 const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+endOfMonth.setHours(23, 59, 59, 999);
 const activities = (
     await userActivity({
         userId: user.id,


### PR DESCRIPTION
This pull request includes a small but important change to the `src/pages/apps/record/index.astro` file. The change ensures that the `startOfMonth` and `endOfMonth` dates have their times set to the beginning and end of the day, respectively.

* [`src/pages/apps/record/index.astro`](diffhunk://#diff-d6f533f5f20269e3ab5ddd2294a1bb2a66cfe9a0a83df62f22f8ab8b35ee5daaR25-R27): Set the time for `startOfMonth` to 00:00:00.000 and for `endOfMonth` to 23:59:59.999.