### PR TITLE
fix: update deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,15 +1,12 @@
 name: Deploy to Production
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - 'main'
 
 jobs:
   deploy-production:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     environment: production
     env:
@@ -33,8 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile
+
       - name: Build
         run: pnpm build
       - name: Deploy to Production


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying to production by changing the trigger event and simplifying the job steps. The most important changes are outlined below:

### Workflow Trigger Updates:
* Changed the workflow trigger from `pull_request` (on closed and merged pull requests) to `push` events on the `main` branch. This ensures deployments occur only when changes are pushed to `main`. (`.github/workflows/deploy-production.yml`, [.github/workflows/deploy-production.ymlL4-L12](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94L4-L12))

### Job Step Simplification:
* Removed a duplicate "Install dependencies" step in the `deploy-production` job, keeping only one instance of the step with the same functionality (`pnpm install --frozen-lockfile`). (`.github/workflows/deploy-production.yml`, [.github/workflows/deploy-production.ymlL36-R33](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94L36-R33))…nstall step