### PR TITLE
fic test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
       branches-ignore:

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -1,5 +1,8 @@
 name: Deploy Developemnt
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,5 +1,8 @@
 name: Deploy to Production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,5 +1,8 @@
 name: Deploy to Staging
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,8 @@
 name: Playwright Tests
+
+permissions:
+  contents: read
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "typecheck": "pnpm cf-typegen && react-router typegen && tsc -b",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
-    "postdocker:up": "pnpm db:migrate"
+    "postdocker:up": "pnpm db:migrate",
+    "docker:db:reset": "docker compose down && docker compose up -d && pnpm db:migrate"
   },
   "dependencies": {
     "@catppuccin/palette": "^1.7.1",

--- a/tests/e2e/components/desktop/addrecord.spec.ts
+++ b/tests/e2e/components/desktop/addrecord.spec.ts
@@ -3,37 +3,24 @@ import { expect, test } from "@playwright/test"
 test.describe("記録操作", () => {
   test("記録の追加から削除まで", async ({ page }) => {
     await page.goto("/record")
-    await expect(page.getByText("登録日月火水木金土")).toBeVisible()
-    const day1Element = await page.waitForSelector("div:has-text('1')")
-    await day1Element.click()
-    await expect(page.getByRole("main")).toContainText("この日の活動記録がありません。")
-    await page.getByRole("button", { name: "記録を追加" }).click()
-    await page.getByRole("button", { name: "一時保存" }).click()
-    const day2Element = await page.waitForSelector("div:has-text('2')")
-    await day2Element.click()
-    await expect(page.getByRole("main")).toContainText("この日の活動記録がありません。")
-    await page.getByRole("button", { name: "記録を追加" }).click()
-    await expect(page.getByText("時間")).toBeVisible()
-    await page.getByRole("button", { name: "戻る" }).click()
-    await page.getByRole("button", { name: "登録" }).click()
-    await page.goto("/record")
-    const summaryElement = await page.waitForSelector("text=1合計 1.5h")
-    await summaryElement.click()
-    await expect(page.getByText("時間")).toBeVisible()
-    await page.getByRole("button", { name: "戻る" }).click()
-    const day2Element2 = await page.waitForSelector("div:has-text('2')")
-    await day2Element2.click()
-    await expect(page.getByText("この日の活動記録がありません。")).toBeVisible()
-    await page.getByRole("button", { name: "戻る" }).click()
-    await expect(page.getByText("1合計 1.5h")).toBeVisible()
-    const summaryElement2 = await page.waitForSelector("text=1合計 1.5h")
-    await summaryElement2.click()
-    await page.getByRole("button", { name: "削除" }).click()
-    await page.getByRole("button", { name: "一時保存" }).click()
-    await page.getByRole("button", { name: "登録" }).click()
-    const day1Element2 = await page.waitForSelector("div:has-text('1')")
-    await day1Element2.click()
-    await page.getByText("この日の活動記録がありません。").click()
-    await expect(page.getByText("この日の活動記録がありません。")).toBeVisible()
+    await expect(page.getByRole('heading', { name: '記録一覧' })).toBeVisible();
+    await expect(page.getByText('日', { exact: true })).toBeVisible();
+    await expect(page.locator('div').filter({ hasText: /^1$/ }).first()).toBeVisible();
+    await page.locator('div').filter({ hasText: /^1$/ }).first().click();
+    await expect(page.getByRole('button', { name: '記録を追加' })).toBeVisible();
+    await page.getByRole('button', { name: '記録を追加' }).click();
+    await expect(page.getByRole('main')).toContainText('時間');
+    await page.getByRole('button', { name: '一時保存' }).click();
+    await expect(page.getByText('合計 1.5h').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: '登録' })).toBeVisible();
+    await page.getByRole('button', { name: '登録' }).click();
+    await page.goto('http://localhost:4173/record');
+    await expect(page.getByText('合計 1.5h').first()).toBeVisible();
+    await page.getByText('1合計 1.5h').click();
+    await expect(page.getByText('時間')).toBeVisible();
+    await page.getByRole('button', { name: '削除' }).click();
+    await expect(page.getByRole('main')).toContainText('この日の活動記録がありません。');
+    await page.getByRole('button', { name: '一時保存' }).click();
+    await page.getByRole('button', { name: '登録' }).click();
   })
 })

--- a/tests/e2e/components/desktop/checkProfile.spec.ts
+++ b/tests/e2e/components/desktop/checkProfile.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  await page.goto("/account")
+  await page.getByRole('link', { name: 'ポータル' }).click();
+  await page.getByRole('link', { name: 'アカウント アカウント設定ページ 詳細を見る' }).click();
+  await expect(page.locator('h1')).toContainText('アカウント: test taro');
+  await page.getByRole('tab', { name: 'ステータス' }).click();
+  await expect(page.locator('form')).toContainText('所持級段位');
+  await page.getByRole('tab', { name: 'プロフィール' }).click();
+  await page.getByRole('link', { name: 'Discordアカウント連携' }).click();
+  await expect(page.getByRole('main')).toContainText('Discord連携する');
+  await page.getByRole('link', { name: 'ポータル' }).click();
+});

--- a/tests/e2e/components/mobile/addrecord.spec.ts
+++ b/tests/e2e/components/mobile/addrecord.spec.ts
@@ -3,39 +3,25 @@ import { expect, test } from "@playwright/test"
 test.describe("記録操作", () => {
   test("記録の追加から削除まで", async ({ page }) => {
     await page.goto("/record")
-    await expect(page.getByRole("heading", { name: "記録一覧" })).toBeVisible()
-    const listItem = await page.waitForSelector('li:has-text("記録なし")')
-    await expect(page.locator("li", { hasText: /記録なし$/ }).first()).toBeVisible()
-    await listItem.click()
-    await expect(page.getByText("この日の活動記録がありません。")).toBeVisible()
-    await page.getByRole("button", { name: "記録を追加" }).click()
-    await page.getByRole("button", { name: "一時保存" }).click()
-    const listItem2 = await page.waitForSelector('li:has-text("記録なし")')
-    await expect(page.locator("li", { hasText: /記録なし$/ }).first()).toBeVisible()
-    await listItem2.click()
-    await expect(page.getByRole("main")).toContainText("この日の活動記録がありません。")
-    await page.getByRole("button", { name: "記録を追加" }).click()
-    await expect(page.getByText("時間")).toBeVisible()
-    await page.getByRole("button", { name: "戻る" }).click()
-    await page.getByRole("button", { name: "登録" }).click()
-    await page.goto("/record")
-    const summaryElement = await page.waitForSelector("text=合計 1.5h")
-    await expect(page.getByText("合計 1.5h")).toBeVisible()
-    await summaryElement.click()
-    await expect(page.getByText("時間")).toBeVisible()
-    await page.getByRole("button", { name: "戻る" }).click()
-    await listItem2.click()
-    await expect(page.getByText("この日の活動記録がありません。")).toBeVisible()
-    await page.getByRole("button", { name: "戻る" }).click()
-    await expect(page.getByText("合計 1.5h")).toBeVisible()
-    const summaryElement2 = await page.waitForSelector("text=合計 1.5h")
-    await summaryElement2.click()
-    await page.getByRole("button", { name: "削除" }).click()
-    await page.getByRole("button", { name: "一時保存" }).click()
-    await page.getByRole("button", { name: "登録" }).click()
-    const finalListItem = await page.waitForSelector('li:has-text("記録なし")')
-    await finalListItem.click()
-    await page.getByText("この日の活動記録がありません。").click()
-    await expect(page.getByText("この日の活動記録がありません。")).toBeVisible()
+    await page.goto('http://localhost:4173/');
+     await page.getByRole('link', { name: '記録 活動の記録をつけよう 詳細を見る' }).click();
+     await expect(page.locator('h1')).toContainText('記録一覧');
+     await expect(page.getByRole('list')).toContainText('1日');
+     await expect(page.getByRole('list')).toContainText('記録なし');
+     await page.getByRole('listitem').filter({ hasText: '記録なし' }).locator('div').nth(1).click();
+     await expect(page.getByRole('main')).toContainText('この日の活動記録がありません。');
+     await page.getByRole('button', { name: '記録を追加' }).click();
+     await expect(page.getByRole('main')).toContainText('時間');
+     await page.getByRole('button', { name: '一時保存' }).click();
+     await expect(page.getByRole('main')).toContainText('登録');
+     await page.getByRole('button', { name: '登録' }).click();
+     await page.goto('http://localhost:4173/record?month=2025-07');
+     await expect(page.getByRole('list')).toContainText('合計 1.5h');
+     await page.getByText('日 (火)合計 1.5h').click();
+     await page.getByRole('button', { name: '削除' }).click();
+     await expect(page.getByRole('main')).toContainText('この日の活動記録がありません。');
+     await page.getByRole('button', { name: '一時保存' }).click();
+     await page.getByRole('button', { name: '登録' }).click();
+     await expect(page.getByRole('list')).toContainText('記録なし');
   })
 })

--- a/tests/e2e/components/mobile/checkProfile.spec.ts
+++ b/tests/e2e/components/mobile/checkProfile.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  await page.goto("/account")
+  await page.getByRole('link', { name: 'ポータル' }).click();
+  await page.getByRole('link', { name: 'アカウント アカウント設定ページ 詳細を見る' }).click();
+  await expect(page.locator('h1')).toContainText('アカウント: test taro');
+  await page.getByRole('tab', { name: 'ステータス' }).click();
+  await expect(page.locator('form')).toContainText('所持級段位');
+  await page.getByRole('tab', { name: 'プロフィール' }).click();
+  await page.getByRole('link', { name: 'Discordアカウント連携' }).click();
+  await expect(page.getByRole('main')).toContainText('Discord連携する');
+  await page.getByRole('link', { name: 'ポータル' }).click();
+});


### PR DESCRIPTION
This pull request introduces several updates across workflows, package scripts, and end-to-end tests. The main changes include adding permissions to GitHub Actions workflows, enhancing `package.json` scripts for database reset functionality, and refactoring Playwright tests for improved readability and functionality.

### Workflow Updates:

* `.github/workflows/ci.yml`, `.github/workflows/deploy-development.yml`, `.github/workflows/deploy-production.yml`, `.github/workflows/deploy-staging.yml`, `.github/workflows/playwright.yml`: Added `permissions` configuration with `contents: read` to ensure workflows have the necessary access permissions. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR3-R5) [[2]](diffhunk://#diff-28d7316e4c50930f6aad2c18f15a1ea3b0fe55207a8b4c1710cc785c6680b572R3-R5) [[3]](diffhunk://#diff-99ce179d261b73100b5672f064452b508820755c8e043e7ea4de36b9ec943d94R3-R5) [[4]](diffhunk://#diff-98b468326a86981405fb6e13c66ea8cd0032c4c7e4f2816fbc42a1fa9b32e991R3-R5) [[5]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R2-R5)

### Package Script Enhancements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R30): Added a new script `docker:db:reset` to streamline resetting the database by stopping, restarting, and migrating the Docker container.

### Test Refactoring:

#### Desktop Tests:
* [`tests/e2e/components/desktop/addrecord.spec.ts`](diffhunk://#diff-8387ccf41a5ca8b9f82fa2af9b04b7d974f9b37cc84271c0f44e129c5e2a600cL6-R24): Refactored the test for activity record operations to use cleaner and more concise Playwright selectors, improving readability and maintainability.
* [`tests/e2e/components/desktop/checkProfile.spec.ts`](diffhunk://#diff-f08f639156baf629fa71f4b8805061c54307aa5186356f4291babd4eeb1e8f6fR1-R14): Added new tests for verifying profile and account settings, including interactions with tabs and Discord account linking.

#### Mobile Tests:
* [`tests/e2e/components/mobile/addrecord.spec.ts`](diffhunk://#diff-902422257eb3ed4f42729249e463b3281c0678e78334e0cfa21780eea5cf2700L6-R25): Refactored the mobile-specific test for activity record operations to align with desktop test improvements, ensuring consistency and clarity.
* [`tests/e2e/components/mobile/checkProfile.spec.ts`](diffhunk://#diff-f08f639156baf629fa71f4b8805061c54307aa5186356f4291babd4eeb1e8f6fR1-R14): Added new tests for mobile profile and account settings, mirroring the desktop test functionality.