### PR TITLE
Remove redundant script-src-elem CSP directive

### DIFF
--- a/workers/app.ts
+++ b/workers/app.ts
@@ -30,7 +30,6 @@ export default {
         `
           default-src 'self';
           script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.omu-aikido.com https://challenges.cloudflare.com;
-          script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.omu-aikido.com https://challenges.cloudflare.com;
           connect-src 'self' https://clerk.omu-aikido.com;
           img-src 'self' https://img.clerk.com;
           worker-src 'self' blob:;


### PR DESCRIPTION
This pull request makes a minor adjustment to the Content Security Policy (CSP) settings in the `workers/app.ts` file by removing the explicit `script-src-elem` directive. This change simplifies the CSP configuration, relying on the broader `script-src` directive for script loading rules.

- Security configuration update:
  * Removed the `script-src-elem` directive from the CSP, consolidating script source restrictions under `script-src`.