### PR TITLE
Refactor Content-Security-Policy definition

### DIFF
--- a/workers/app.ts
+++ b/workers/app.ts
@@ -27,16 +27,16 @@ export default {
       response.headers.set("X-Content-Type-Options", "nosniff")
       response.headers.set(
         "Content-Security-Policy",
-        `
-          default-src 'self';
-          script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.omu-aikido.com https://challenges.cloudflare.com;
-          connect-src 'self' https://clerk.omu-aikido.com;
-          img-src 'self' https://img.clerk.com;
-          worker-src 'self' blob:;
-          style-src 'self' 'unsafe-inline';
-          frame-src 'self' https://challenges.cloudflare.com;
-          form-action 'self';
-        `,
+        [
+          "default-src 'self'",
+          "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.omu-aikido.com https://challenges.cloudflare.com",
+          "connect-src 'self' https://clerk.omu-aikido.com",
+          "img-src 'self' https://img.clerk.com",
+          "worker-src 'self' blob:",
+          "style-src 'self' 'unsafe-inline'",
+          "frame-src 'self' https://challenges.cloudflare.com",
+          "form-action 'self'",
+        ].join(";"),
       )
       response.headers.set(
         "Strict-Transport-Security",


### PR DESCRIPTION
This pull request refactors how the Content Security Policy (CSP) header is set in the `workers/app.ts` file. The policy definition is now constructed as an array of strings and joined with semicolons, rather than using a multiline template string. This change improves readability and maintainability of the CSP configuration.

- Security header improvement:
  * Refactored the Content Security Policy header construction to use an array of directives joined by semicolons, making the policy easier to read and modify in `workers/app.ts`.