### PR TITLE
feat: Add logging for authentication errors

### DIFF
--- a/logtape.config.ts
+++ b/logtape.config.ts
@@ -2,5 +2,8 @@ import { configure, getConsoleSink } from "@logtape/logtape"
 
 await configure({
   sinks: { console: getConsoleSink() },
-  loggers: [{ category: "record", lowestLevel: "debug", sinks: ["console"] }],
+  loggers: [
+    { category: "record", lowestLevel: "debug", sinks: ["console"] },
+    { category: "auth", lowestLevel: "error", sinks: ["console"] },
+  ],
 })


### PR DESCRIPTION
This pull request enhances the user experience and error handling on the sign-up page, particularly around email verification. It introduces detailed error messages for different failure scenarios, adds logging for authentication errors, and implements a resend feature for the verification code with a cooldown timer. Additionally, logging configuration is updated to support the new authentication logger.

**Authentication error handling and user experience improvements:**

* Added detailed error handling for email verification failures, providing user-friendly messages for specific error codes (e.g., incorrect code, expired code, rate limit exceeded, invalid session) and network issues. Errors are also logged for better debugging.
* Implemented a resend verification code feature with a 60-second cooldown timer, including UI feedback and error handling for resend failures. [[1]](diffhunk://#diff-682a367dcf035366eb67c55a6658bd17146da832e0f5e6eee9175dd81a7dc47cR141) [[2]](diffhunk://#diff-682a367dcf035366eb67c55a6658bd17146da832e0f5e6eee9175dd81a7dc47cR285-R361) [[3]](diffhunk://#diff-682a367dcf035366eb67c55a6658bd17146da832e0f5e6eee9175dd81a7dc47cR441-R464)

**Logging enhancements:**

* Integrated `@logtape/logtape` for authentication-related logging by creating a dedicated logger in the sign-up page logic. [[1]](diffhunk://#diff-682a367dcf035366eb67c55a6658bd17146da832e0f5e6eee9175dd81a7dc47cR3) [[2]](diffhunk://#diff-682a367dcf035366eb67c55a6658bd17146da832e0f5e6eee9175dd81a7dc47cR14-R15)
* Updated `logtape.config.ts` to register an "auth" logger with error-level logging to the console.

**UI improvements:**

* Improved the verification code input by adding a placeholder and disabling the submit button unless a code is entered.