### PR TITLE
chor

### DIFF
--- a/app/routes/sign-up+/verify.tsx
+++ b/app/routes/sign-up+/verify.tsx
@@ -210,17 +210,14 @@ export default function VerifyPage() {
                 className={style.button({ type: "danger", class: "text-sm" })}
                 onClick={() => {
                   if (
-                    window.confirm(
-                      "サインアップページに戻りますか？進捗はリセットされます。",
-                    )
+                    window.confirm("入力はリセットされます。よろしいですか？")
                   ) {
-                    history.replaceState("", "/sign-up")
+                    navigate("/sign-up")
                   }
                 }}
               >
-                サインアップページに戻る
+                最初からやり直す
               </button>
-              <p className={style.text.info({ class: "mt-2" })}>進捗がリセットされます</p>
             </div>
           </>
         )


### PR DESCRIPTION
This pull request updates the user experience for resetting progress on the sign-up verification page. The confirmation message, navigation behavior, and button text have been revised for clarity and consistency.

User experience improvements:

* Updated the confirmation dialog message to "入力はリセットされます。よろしいですか？" for clearer communication.
* Changed navigation logic to use `navigate("/sign-up")` instead of `history.replaceState`, ensuring proper routing.
* Updated the button label to "最初からやり直す" for better clarity.
* Removed the additional info text "進捗がリセットされます" for a cleaner interface.