### PR TITLE
feat(auth): use Cloudflare context for clerk keys

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,6 +9,7 @@ import {
   Scripts,
   ScrollRestoration,
 } from "react-router"
+import { CloudflareContext } from "workers/app"
 
 import type { Route } from "./+types/root"
 
@@ -26,7 +27,11 @@ export const links: Route.LinksFunction = () => [
 // eslint-disable-next-line react-refresh/only-export-components
 export const middleware: Route.MiddlewareFunction[] = [clerkMiddleware()]
 
-export const loader = (args: Route.LoaderArgs) => rootAuthLoader(args)
+export const loader = (args: Route.LoaderArgs) =>
+  rootAuthLoader(args, {
+    secretKey: args.context.get(CloudflareContext).env.CLERK_SECRET_KEY,
+    publishableKey: args.context.get(CloudflareContext).env.CLERK_PUBLISHABLE_KEY,
+  })
 
 export default function App({ loaderData }: Route.ComponentProps) {
   return (


### PR DESCRIPTION
Retrieve CLERK_SECRET_KEY and CLERK_PUBLISHABLE_KEY from the
CloudflareContext in the root loader and pass them to rootAuthLoader.
This allows the app to obtain Clerk credentials from the Cloudflare
Router context instead of relying on prior environment access methods.