### PR TITLE
fix format start and end dates as date-only strings.

### DIFF
--- a/app/lib/query/activity.ts
+++ b/app/lib/query/activity.ts
@@ -260,8 +260,8 @@ export async function getUserMonthlyRank(input: {
   const startDate = new Date(input.year, input.month, 1, 9)
   const endDate = new Date(input.year, input.month + 1, 0, 23, 59, 59)
 
-  const startDateStr = startDate.toISOString()
-  const endDateStr = endDate.toISOString()
+  const startDateStr = startDate.toISOString().split("T")[0]
+  const endDateStr = endDate.toISOString().split("T")[0]
 
   // 全ユーザーの月次合計を取得（順位付けのため）
   const allUserTotals = await db


### PR DESCRIPTION
This pull request makes a minor update to the way date strings are formatted in the `getUserMonthlyRank` function. The change ensures that only the date part (YYYY-MM-DD) is used, rather than the full ISO string with time.

- Changed `startDateStr` and `endDateStr` to use only the date portion (YYYY-MM-DD) from the ISO string in `getUserMonthlyRank` in `activity.ts`.