### PR TITLE
standardizes `getGradeAt` date format to YYYY-MM-DD, improving consistency and preventing time zone issues.

### DIFF
--- a/app/routes/onboarding.tsx
+++ b/app/routes/onboarding.tsx
@@ -186,7 +186,7 @@ export async function action(args: Route.ActionArgs) {
         const dateStr = unsafeMetadata.getGradeAt.trim()
         const date = new Date(dateStr)
         if (!isNaN(date.getTime())) {
-          getGradeAt = date.toISOString()
+          getGradeAt = date.toISOString().split("T")[0]
         }
       }
 

--- a/tests/e2e/security/_helper.ts
+++ b/tests/e2e/security/_helper.ts
@@ -11,7 +11,7 @@ export function updateRole({ role }: { role: string }) {
     year: "b2",
     grade: 3,
     joinedAt: 2025,
-    getGradeAt: "2025-07-19T00:00:00.000Z",
+    getGradeAt: "2025-07-19",
   }
   client.users
     .getUser(userId)


### PR DESCRIPTION
This pull request standardizes the `getGradeAt` date format throughout the codebase by ensuring that only the date portion (YYYY-MM-DD) is used, rather than the full ISO string with time. This change improves consistency and likely prevents issues related to time zones or unwanted time information.

Date format standardization:

* Updated both the `loader` and `action` functions in `app/routes/onboarding.tsx` to store `getGradeAt` as a date string in the `YYYY-MM-DD` format instead of the full ISO string with time. [[1]](diffhunk://#diff-3dfa43d4741b210a2cee5e80a63b5578f9481d9d4df25f38fd499b10547d12beL83-R83) [[2]](diffhunk://#diff-3dfa43d4741b210a2cee5e80a63b5578f9481d9d4df25f38fd499b10547d12beL189-R189)
* Modified the test helper in `tests/e2e/security/_helper.ts` to use the new date-only format for `getGradeAt`.