### PR TITLE
Refine user activity filtering with joinedAt fallback

### DIFF
--- a/server/app/admin/stats.ts
+++ b/server/app/admin/stats.ts
@@ -72,13 +72,12 @@ async function getUsersNorm(env: Env, clerkUsers: User[]) {
   if (validProfiles.length === 0) return [];
 
   const conditions = validProfiles.map((profile) => {
-    if (profile.getGradeAt) {
-      return drizzleOrm.and(
-        drizzleOrm.eq(activity.userId, profile.id),
-        drizzleOrm.gte(activity.date, profile.getGradeAt)
-      );
-    }
-    return drizzleOrm.eq(activity.userId, profile.id);
+    // Use getGradeAt if available, otherwise fallback to joinedAt
+    const gradeDate = profile.getGradeAt ?? String(profile.joinedAt ?? new Date().getFullYear());
+    return drizzleOrm.and(
+      drizzleOrm.eq(activity.userId, profile.id),
+      drizzleOrm.gt(activity.date, gradeDate)
+    );
   });
 
   const activityData = await db


### PR DESCRIPTION
Use getGradeAt if available, otherwise fallback to joinedAt (or current year). Change date comparison from >= to > for stricter filtering.