### PR TITLE
Feat: Add calendar link to navigation

### DIFF
--- a/apps/client/src/components/home/PracticeCountGraph.vue
+++ b/apps/client/src/components/home/PracticeCountGraph.vue
@@ -50,9 +50,10 @@ const needToNextGrade = computed(() => {
 });
 
 const progressPercentage = computed(() => {
-  if (!props.practiceData) return 0;
+  if (!props.practiceData || !requiredCount.value) return 0;
   const percentage = (props.practiceData.practiceCount / requiredCount.value) * 100;
-  return Math.min(Math.round(percentage), 100);
+  const result = Math.min(Math.round(percentage), 100);
+  return isNaN(result) ? 0 : result;
 });
 
 const progressComment = computed(() => {
@@ -77,53 +78,40 @@ const progressComment = computed(() => {
 
 <template>
   <div class="w-full" data-testid="practice-count-graph">
-    <div v-if="loading" class="card animate-pulse rounded" data-testid="skeleton">
-      <div class="flex flex-col items-center justify-center">
-        <div class="bg-overlay1 rounded flex justify-center">
-          <span class="text-transparent"> &nbsp;&nbsp; </span>
-        </div>
-        <div class="max-w-96 py-4 w-full">
-          <div class="rounded-md h-2 bg-overlay0 w-full">
-            <div class="rounded-md bg-text h-full max-w-full" style="width: 0" />
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div v-else-if="error" class="py-8 text-center">
+    <div v-if="error" class="py-8 text-center">
       <div class="text-sm text-red-500">エラー: {{ error }}</div>
     </div>
 
-    <details v-else-if="practiceData" class="card select-none">
+    <details v-else class="card select-none">
       <summary class="rounded-lg cursor-pointer list-none [&::-webkit-details-marker]:hidden">
         <div class="flex w-full cursor-pointer flex-col items-center justify-center">
-          <div class="text-lg">
-            {{ translateGrade(targetGrade) }}{{ promotionType }}まで
-            <span class="text font-bold text-3xl">{{ needToNextGrade }}</span>
-            日
+          <div
+            class="transition-all duration-200"
+            :class="[loading ? 'bg-overlay1 rounded flex justify-center min-w-[120px]' : 'text-lg']">
+            <span class="transition-opacity duration-200" :class="loading ? 'invisible' : 'visible'">
+              {{ translateGrade(targetGrade) }}{{ promotionType }}まで
+              <span class="text font-bold text-3xl">{{ needToNextGrade }}</span>
+              日
+            </span>
           </div>
 
           <div class="max-w-96 py-4 w-full">
-            <div class="rounded-md h-2 bg-surface1 w-full">
+            <div class="rounded-md h-2" :class="loading ? 'bg-overlay0' : 'bg-surface1'">
               <div
                 class="rounded-md bg-text h-full max-w-full"
-                :style="{ width: `${progressPercentage}%` }"
-                data-testid="progress-bar" />
+                :style="{ width: loading ? '0%' : `${progressPercentage}%` }"
+                :data-testid="!loading ? 'progress-bar' : undefined" />
             </div>
           </div>
         </div>
       </summary>
 
-      <div class="p-4 border-overlay1 border-t">
+      <div v-if="practiceData && !loading" class="p-4 border-overlay1 border-t">
         <div class="space-y-3">
-          <p class="text">
-            {{ progressComment }}
-          </p>
+          <p class="text">{{ progressComment }}</p>
           <p>
             目標の<span class="font-bold">{{ translateGrade(targetGrade) }}</span
-            >への{{ promotionType }}まで
-            <span class="font-bold">{{ requiredCount }}日分</span>
-            の稽古が必要です。
+            >への{{ promotionType }}まで <span class="font-bold">{{ requiredCount }}日分</span>の稽古が必要です。
           </p>
           <p class="mt-2">
             現在、<span class="text-green-500 font-medium">{{ practiceData.practiceCount }}日</span>達成しています。

--- a/apps/client/src/components/pages/SidePanel.vue
+++ b/apps/client/src/components/pages/SidePanel.vue
@@ -43,6 +43,15 @@
                 <UserAvatar alt="User Avatar" rounded />
                 アカウント設定
               </RouterLink>
+              <hr />
+              <a
+                href="https://omu-aikido.com/calendar"
+                class="flex-inline gap-2 text items-center"
+                target="_blank"
+                @click="close">
+                <div class="i-lucide:calendar" />
+                カレンダー ↗
+              </a>
             </nav>
           </Show>
         </div>

--- a/apps/client/src/pages/Home.vue
+++ b/apps/client/src/pages/Home.vue
@@ -23,6 +23,7 @@ const iconMap = {
   'clipboard-list': 'i-lucide:clipboard-list',
   user: 'i-lucide:user',
   settings: 'i-lucide:settings',
+  calendar: 'i-lucide:calendar',
 };
 // Queries
 const { data: profileData } = useQuery({
@@ -128,6 +129,7 @@ const getNavLabelClass = (theme: string) => {
             :key="item.id"
             :to="item.href.startsWith('http') ? undefined : item.href"
             :href="item.href.startsWith('http') ? item.href : undefined"
+            :target="item.href.startsWith('http') ? '_blank' : undefined"
             :class="[
               'group gap-3 card text hover:shadow-md flex cursor-pointer flex-col items-center justify-center no-underline transition-colors transition-shadow',
               getNavItemClass(item.theme),

--- a/apps/server/src/app/user/clerk.ts
+++ b/apps/server/src/app/user/clerk.ts
@@ -138,6 +138,13 @@ export const clerk = new Hono<{ Bindings: Env }>() //
         icon: 'user',
         theme: 'green',
       },
+      {
+        id: 'schedule',
+        title: 'カレンダー ↗',
+        href: 'https://omu-aikido.com/calendar',
+        icon: 'calendar',
+        theme: 'blue',
+      },
     ];
 
     if (isManagement) {


### PR DESCRIPTION
Updates the navigation structure in `Home.vue` and adds a corresponding entry to
the site map in the server-side Clerk configuration.
This pull request enhances the user experience in the practice progress and navigation components, primarily by improving loading state handling, error display, and adding a direct link to the external calendar. The most significant changes include more robust progress calculation, a refined loading skeleton for the practice graph, and new navigation options for accessing the calendar.

**Practice Progress Improvements:**
- Improved the calculation of `progressPercentage` in `PracticeCountGraph.vue` to handle cases where the required count is missing or zero, ensuring the progress bar never displays NaN or incorrect values.
- Refined the loading and error states in the practice progress card: replaced the previous loading skeleton with a smoother transition, made the error display more prominent, and ensured the progress details are only shown when data is available and not loading.

**Navigation Enhancements:**
- Added a new navigation entry for the external calendar (`https://omu-aikido.com/calendar`) to the side panel and the main navigation, including a calendar icon and an external link indicator. This allows users to quickly access the calendar in a new tab. [[1]](diffhunk://#diff-332914dcb30a97e8cafcc904ab031675003ca55d466b25deba70ae63e9f749a0R141-R147) [[2]](diffhunk://#diff-acd7948d5e059a69bfb34acc321b3ae888609d182e009a44ed76a384925d6620R46-R54) [[3]](diffhunk://#diff-965052d5c28406700303c65c1f1343cd3df19a60b01110604aa61aa0eb2106dbR26) [[4]](diffhunk://#diff-965052d5c28406700303c65c1f1343cd3df19a60b01110604aa61aa0eb2106dbR132)