### PR TITLE
fix(share): enforce strict YYYY-MM-DD for activity date

### DIFF
--- a/apps/share/src/records.ts
+++ b/apps/share/src/records.ts
@@ -7,7 +7,7 @@ export const recordQuerySchema = type({
 });
 
 export const createActivitySchema = type({
-  date: 'string',
+  date: /^\d{4}-\d{2}-\d{2}$/,
   period: 'number > 0',
 });
 

--- a/apps/share/src/records.ts
+++ b/apps/share/src/records.ts
@@ -1,5 +1,23 @@
 import { type } from 'arktype';
 
+function isStrictIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const [yearText, monthText, dayText] = value.split('-');
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() + 1 === month &&
+    date.getUTCDate() === day
+  );
+}
+
 export const recordQuerySchema = type({
   'userId?': /^user_[\w]{27}$/,
   'startDate?': /^\d{4}-\d{2}-\d{2}$/,
@@ -9,7 +27,7 @@ export const recordQuerySchema = type({
 export const createActivitySchema = type({
   date: /^\d{4}-\d{2}-\d{2}$/,
   period: 'number > 0',
-});
+}).narrow((input) => isStrictIsoDate(input.date));
 
 export const deleteActivitiesSchema = type({ ids: 'string[]' });
 

--- a/apps/share/test/records.test.ts
+++ b/apps/share/test/records.test.ts
@@ -250,4 +250,24 @@ describe('createActivitySchema', () => {
     const result = createActivitySchema({ date: 'hello', period: 1.5 });
     expect(isValid(result)).toBe(false);
   });
+
+  test('should reject impossible calendar date', () => {
+    const result = createActivitySchema({ date: '2024-02-31', period: 1.5 });
+    expect(isValid(result)).toBe(false);
+  });
+
+  test('should reject month out of range', () => {
+    const result = createActivitySchema({ date: '2024-13-01', period: 1.5 });
+    expect(isValid(result)).toBe(false);
+  });
+
+  test('should accept leap day on leap year', () => {
+    const result = createActivitySchema({ date: '2024-02-29', period: 1.5 });
+    expect(isValid(result)).toBe(true);
+  });
+
+  test('should reject leap day on non-leap year', () => {
+    const result = createActivitySchema({ date: '2023-02-29', period: 1.5 });
+    expect(isValid(result)).toBe(false);
+  });
 });

--- a/apps/share/test/records.test.ts
+++ b/apps/share/test/records.test.ts
@@ -211,6 +211,11 @@ describe('createActivitySchema', () => {
     expect(isValid(result)).toBe(true);
   });
 
+  test('should accept YYYY-MM-DD date format only', () => {
+    const result = createActivitySchema({ date: '1999-12-31', period: 2 });
+    expect(isValid(result)).toBe(true);
+  });
+
   test('should reject missing date', () => {
     const result = createActivitySchema({ period: 1.5 });
     expect(isValid(result)).toBe(false);
@@ -229,5 +234,20 @@ describe('createActivitySchema', () => {
   test('should accept valid date string', () => {
     const result = createActivitySchema({ date: '2024-01-01', period: 1.5 });
     expect(isValid(result)).toBe(true);
+  });
+
+  test('should reject date without zero padding', () => {
+    const result = createActivitySchema({ date: '2024-1-1', period: 1.5 });
+    expect(isValid(result)).toBe(false);
+  });
+
+  test('should reject date with slash separator', () => {
+    const result = createActivitySchema({ date: '2024/01/01', period: 1.5 });
+    expect(isValid(result)).toBe(false);
+  });
+
+  test('should reject non-date string', () => {
+    const result = createActivitySchema({ date: 'hello', period: 1.5 });
+    expect(isValid(result)).toBe(false);
   });
 });


### PR DESCRIPTION
## 概要
- 活動記録作成時の `date` 入力を厳格化し、`YYYY-MM-DD` 形式のみ受け入れるように変更

## 変更内容
- `createActivitySchema.date` を `string` から `YYYY-MM-DD` パターンへ制限
- shareユニットテストに正常系/異常系を追加
- 既存のAPI契約（Hono RPC型利用）は維持

## スコープ
- このPRは**入力制約強化のみ**
- 既存データ移行は行わない

## テスト
- `bun test apps/share/test/records.test.ts`
- `bun test`