### PR TITLE
fix(admin): correct doneTrain baseline date calculation

### DIFF
--- a/apps/server/src/app/admin/helpers.ts
+++ b/apps/server/src/app/admin/helpers.ts
@@ -97,3 +97,21 @@ export function formatDateToJSTString(date: Date): string {
   const jstDate = getJST(date);
   return jstDate.toISOString().split('T')[0]!;
 }
+
+type GradeDateProfile = {
+  getGradeAt?: string | null;
+  joinedAt?: number | null;
+};
+
+export function resolveTrainBaselineDate(profile: GradeDateProfile | null | undefined, now = new Date()): Date {
+  if (profile?.getGradeAt) {
+    return new Date(`${profile.getGradeAt}T00:00:00.000Z`);
+  }
+
+  const joinedYear = profile?.joinedAt ?? now.getFullYear();
+  return new Date(Date.UTC(joinedYear, 3, 1));
+}
+
+export function isDoneTrainTargetDate(activityDate: string, baselineDate: Date): boolean {
+  return new Date(`${activityDate}T00:00:00.000Z`) >= baselineDate;
+}

--- a/apps/server/src/app/admin/users.ts
+++ b/apps/server/src/app/admin/users.ts
@@ -97,12 +97,10 @@ const app = new Hono<{ Bindings: Env }>()
       const totalHours = allActivities.reduce((sum, a) => sum + (a.period || 0), 0);
       const totalDays = new Set(allActivities.map((a) => a.date)).size;
 
-      const getGradeAtDate = profile?.getGradeAt
-        ? new Date(profile.getGradeAt)
-        : helpers.getJST(new Date(profile?.joinedAt ?? new Date().getFullYear()));
+      const getGradeAtDate = helpers.resolveTrainBaselineDate(profile);
 
       const trainsAfterGrade = allActivities
-        .filter((a) => new Date(a.date) > getGradeAtDate)
+        .filter((a) => helpers.isDoneTrainTargetDate(a.date, getGradeAtDate))
         .map((a) => a.period)
         .reduce((sum, period) => sum + period, 0);
 

--- a/apps/server/test/admin/helpers.test.ts
+++ b/apps/server/test/admin/helpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { isDoneTrainTargetDate, resolveTrainBaselineDate } from '../../src/app/admin/helpers';
+
+describe('resolveTrainBaselineDate', () => {
+  test('joinedAt only: uses April 1st of joined year as baseline', () => {
+    const baseline = resolveTrainBaselineDate({ joinedAt: 2024 });
+    expect(baseline.toISOString()).toBe('2024-04-01T00:00:00.000Z');
+  });
+
+  test('getGradeAt has priority over joinedAt', () => {
+    const baseline = resolveTrainBaselineDate({ getGradeAt: '2025-06-15', joinedAt: 2020 });
+    expect(baseline.toISOString()).toBe('2025-06-15T00:00:00.000Z');
+  });
+
+  test('doneTrain boundary: baseline date itself is included', () => {
+    const baseline = resolveTrainBaselineDate({ getGradeAt: '2024-04-01' });
+    expect(isDoneTrainTargetDate('2024-04-01', baseline)).toBe(true);
+    expect(isDoneTrainTargetDate('2024-03-31', baseline)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
- Admin UserDetailの `doneTrain` 計算で、`getGradeAt` 未設定時の基準日解釈を修正

## 不具合原因
- `joinedAt`（年度）に対して `new Date(2024)` のようなDate constructor誤用が起き、意図しない日付解釈になっていた

## 変更内容
- `getGradeAt` がある場合はそれを最優先
- ない場合は `joinedAt` 年度を `YYYY-04-01` に変換して比較
- `doneTrain` 境界を「基準日当日を含む（>=）」に明確化
- レスポンス形は変更なし

## テスト
- joinedAtのみ設定ケースで妥当な判定
- getGradeAt優先ロジック維持
- 境界日（当日含む/前日除外）確認
- `bun test apps/server/test/admin/helpers.test.ts`
- `bun test`