### PR TITLE
fix(client): invoke isManagement() in admin guard

### DIFF
--- a/apps/client/src/router/adminGuard.ts
+++ b/apps/client/src/router/adminGuard.ts
@@ -1,0 +1,6 @@
+import { Role } from 'share';
+
+export function isAdminRole(roleValue: unknown): boolean {
+  const role = Role.fromString(`${roleValue}`);
+  return role ? role.isManagement() : false;
+}

--- a/apps/client/src/router/index.ts
+++ b/apps/client/src/router/index.ts
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 
-import { Role } from 'share';
+import { isAdminRole } from './adminGuard';
 
 import HomeView from '@/pages/Home.vue';
 import NotFoundView from '@/pages/NotFound.vue';
@@ -127,8 +127,7 @@ router.beforeEach(async (to, _from) => {
       }
 
       const roleValue = (clerk.user?.publicMetadata as { role?: string })?.role;
-      const role = Role.fromString(`${roleValue}`);
-      const isAdmin = role ? role.isManagement : false;
+      const isAdmin = isAdminRole(roleValue);
 
       if (!isAdmin) {
         return { name: 'home' };

--- a/apps/client/test/router/adminGuard.test.ts
+++ b/apps/client/test/router/adminGuard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isAdminRole } from '../../src/router/adminGuard';
+
+describe('router admin guard role handling', () => {
+  test('returns true for management role', () => {
+    expect(isAdminRole('admin')).toBe(true);
+  });
+
+  test('returns false for member role', () => {
+    expect(isAdminRole('member')).toBe(false);
+  });
+
+  test('returns false for unknown role', () => {
+    expect(isAdminRole('unknown')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
- router guardで `role.isManagement` を関数参照のまま評価していた不具合を修正

## 変更内容
- `role ? role.isManagement : false` を `role ? role.isManagement() : false` 相当に修正
- 判定を `isAdminRole` ヘルパーへ分離してテスト容易性を向上
- 他の認証遷移（未ログイン->signIn、ログイン済みでsignIn系アクセス時home遷移）は維持

## 注意点
- これは**セキュリティ突破の修正ではなく、UXガード不全の修正**
- サーバー側認可が最終防衛である前提は変更なし

## テスト
- admin/member/unknown の分岐をユニットテストで確認
- `bun test apps/client/test/router/adminGuard.test.ts`
- `bun test`