### PR TITLE
Add shared profile and admin account flows

### DIFF
--- a/apps/client/src/components/account/ProfileCard.vue
+++ b/apps/client/src/components/account/ProfileCard.vue
@@ -26,11 +26,22 @@
     </div>
 
     <div v-else-if="!isEditing" class="stack">
+      <div
+        v-if="needsProfileCompletion"
+        class="rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700">
+        プロフィール情報に未入力があります。誕生日を含む必要項目を登録してください。
+      </div>
       <div class="flex-between">
         <h3 class="text-lg font-bold text">プロフィール</h3>
-        <button type="button" class="btn-secondary px-3 py-1.5 text-sm" @click="isEditing = true">編集</button>
+        <button type="button" class="btn-secondary px-3 py-1.5 text-sm" @click="isEditing = true">
+          {{ needsProfileCompletion ? '入力する' : '編集' }}
+        </button>
       </div>
       <div class="gap-3 text-subtext flex flex-col">
+        <div class="py-1 flex items-center justify-between">
+          <span class="text-subtext">誕生日</span>
+          <span class="font-medium text">{{ formatDateSlash(profile?.birthday) }}</span>
+        </div>
         <div class="py-1 flex items-center justify-between">
           <span class="text-subtext">級段位</span>
           <span class="font-medium text">{{ translateGrade(profile?.grade ?? '') || '-' }}</span>
@@ -60,7 +71,7 @@
             <ListboxButton
               class="rounded-md bg-surface0 border-overlay0 px-3 py-2 pr-10 text text focus:ring-blue-500 relative w-full cursor-default border text-left focus:ring-2 focus:outline-none">
               <span class="block overflow-hidden text-ellipsis whitespace-nowrap">{{
-                translateGrade(formData.grade)
+                translateGrade(formData.grade ?? '')
               }}</span>
               <span class="inset-0 right-0 pr-2 pointer-events-none absolute flex items-center justify-end">
                 <div class="i-lucide:lucide:chevrons-up-down w-4 h-4 text-subtext" aria-hidden="true" />
@@ -99,6 +110,8 @@
       </div>
 
       <Input v-model="formData.getGradeAt" type="date" label="取得日" />
+
+      <Input v-model="formData.birthday" type="date" label="誕生日" />
 
       <Input v-model="formData.joinedAt" type="number" label="入部年" min="2020" max="9999" />
 
@@ -162,11 +175,11 @@
 </template>
 
 <script setup lang="ts">
-import { AccountMetadata } from 'share';
 import { ArkErrors } from 'arktype';
 import hc from '@/lib/honoClient';
 import Input from '@/components/ui/UiInput.vue';
 import { queryKeys } from '@/lib/queryKeys';
+import { AccountMetadata, formatDateSlash, isProfileComplete } from 'share';
 import { computed, reactive, ref, watch } from 'vue';
 import { grade, translateGrade } from 'share';
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/vue';
@@ -174,10 +187,11 @@ import { translateYear, year } from 'share';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
 
 interface FormData {
-  grade: number;
+  grade: number | null;
   getGradeAt: string;
-  joinedAt: number;
+  joinedAt: number | null;
   year: `b${number}` | `m${number}` | `d${number}`;
+  birthday: string;
 }
 
 const queryClient = useQueryClient();
@@ -191,8 +205,9 @@ const yearOptions = year;
 const formData = reactive<FormData>({
   grade: 0,
   getGradeAt: '',
-  joinedAt: new Date().getFullYear(),
+  joinedAt: null,
   year: 'b1',
+  birthday: '',
 });
 
 // Query - Returns { profile: ... } to match server response shape
@@ -208,35 +223,41 @@ const { data: profileData } = useQuery({
         console.error(profileParsed);
         throw new Error('Invalid profile data');
       }
-      return { profile: profileParsed };
+      return { profile: profileParsed, needsProfileCompletion: Boolean(data.needsProfileCompletion) };
     }
-    return { profile: null };
+    return { profile: null, needsProfileCompletion: true };
   },
 });
 
 const profile = computed(() => profileData.value?.profile ?? null);
+const needsProfileCompletion = computed(() => profileData.value?.needsProfileCompletion ?? true);
+
+function applyProfileToForm(newProfile: typeof profile.value) {
+  if (newProfile) {
+    formData.grade = Number(newProfile.grade) || 0;
+    formData.getGradeAt = newProfile.getGradeAt || '';
+    formData.joinedAt = newProfile.joinedAt ?? new Date().getFullYear();
+    formData.year = (newProfile.year || 'b1') as `b${number}` | `m${number}` | `d${number}`;
+    formData.birthday = newProfile.birthday || '';
+    return;
+  }
+
+  formData.grade = 0;
+  formData.getGradeAt = '';
+  formData.joinedAt = new Date().getFullYear();
+  formData.year = 'b1';
+  formData.birthday = '';
+}
 
 // Sync form data
 watch(
   profile,
-  (newProfile) => {
-    if (newProfile) {
-      formData.grade = Number(newProfile.grade) || 0;
-      formData.getGradeAt = newProfile.getGradeAt || '';
-      formData.joinedAt = Number(newProfile.joinedAt) || new Date().getFullYear();
-      formData.year = newProfile.year || 'b1';
-    }
-  },
+  (newProfile) => applyProfileToForm(newProfile),
   { immediate: true }
 );
 
 function updateFormData() {
-  if (profile.value) {
-    formData.grade = Number(profile.value.grade) || 0;
-    formData.getGradeAt = profile.value.getGradeAt || '';
-    formData.joinedAt = Number(profile.value.joinedAt) || new Date().getFullYear();
-    formData.year = profile.value.year || 'b1';
-  }
+  applyProfileToForm(profile.value);
 }
 
 // Mutation
@@ -244,8 +265,9 @@ const { mutateAsync: updateProfile, isPending: isSubmitting } = useMutation({
   mutationFn: async (json: {
     grade: number;
     getGradeAt: `${number}-${number}-${number}` | null;
-    joinedAt: number;
+    joinedAt: number | null;
     year: `b${number}` | `m${number}` | `d${number}`;
+    birthday: `${number}-${number}-${number}` | null;
   }) => {
     const res = await hc.user.clerk.profile.$patch({ json });
     if (!res.ok) throw new Error('プロフィールの更新に失敗しました');
@@ -261,12 +283,16 @@ const { mutateAsync: updateProfile, isPending: isSubmitting } = useMutation({
         getGradeAt: responseData.profile.getGradeAt,
         joinedAt: responseData.profile.joinedAt,
         year: responseData.profile.year,
+        birthday: responseData.profile.birthday,
       });
       if (validatedProfile instanceof ArkErrors) {
         console.error(validatedProfile);
       } else {
         // Set cache with consistent { profile: ... } shape
-        queryClient.setQueryData(queryKeys.user.clerk.profile(), { profile: validatedProfile });
+        queryClient.setQueryData(queryKeys.user.clerk.profile(), {
+          profile: validatedProfile,
+          needsProfileCompletion: !isProfileComplete(validatedProfile),
+        });
       }
     }
 
@@ -284,12 +310,14 @@ async function handleSubmit() {
   isError.value = false;
   try {
     const getGradeAtValue = (formData.getGradeAt || null) as `${number}-${number}-${number}` | null;
+    const birthdayValue = (formData.birthday || null) as `${number}-${number}-${number}` | null;
 
     const updateData = {
-      grade: formData.grade,
+      grade: formData.grade ?? 0,
       getGradeAt: getGradeAtValue,
       joinedAt: formData.joinedAt,
       year: formData.year as `b${number}` | `m${number}` | `d${number}`,
+      birthday: birthdayValue,
     };
 
     await updateProfile(updateData);

--- a/apps/client/src/components/signup/SignUpStepProfile.vue
+++ b/apps/client/src/components/signup/SignUpStepProfile.vue
@@ -53,6 +53,16 @@
       :error="formErrors.getGradeAt"
       @update:model-value="onUpdate('getGradeAt', $event)" />
 
+    <Input
+      id="birthday"
+      :model-value="formValues.birthday"
+      type="date"
+      label="誕生日"
+      required
+      :disabled="isSignUpCreated"
+      :error="formErrors.birthday"
+      @update:model-value="onUpdate('birthday', $event)" />
+
     <div class="gap-2 flex items-center">
       <input
         id="legalAccepted"

--- a/apps/client/src/composable/useSignUpForm.ts
+++ b/apps/client/src/composable/useSignUpForm.ts
@@ -4,7 +4,7 @@ import { ArkErrors, type } from 'arktype';
 import { reactive, readonly, ref } from 'vue';
 
 const formDataSchema = type({
-  email: /.+@.+\..+/,
+  email: /.+@.+\..+/u,
   newPassword: '10<=string<=100',
   firstName: '2<=string<=50',
   lastName: '2<=string<=50',
@@ -13,6 +13,7 @@ const formDataSchema = type({
   grade: 'number',
   joinedAt: 'number',
   getGradeAt: 'string | null',
+  birthday: 'string',
   legalAccepted: 'boolean',
 });
 
@@ -24,7 +25,7 @@ type SignUpStep = 'basic' | 'personal' | 'profile';
 const getValidationSchema = (currentStep: SignUpStep) => {
   switch (currentStep) {
     case 'basic':
-      return type({ email: /.+@.+\..+/, newPassword: '10<=string<=100' });
+      return type({ email: /.+@.+\..+/u, newPassword: '10<=string<=100' });
     case 'personal':
       return type({
         firstName: '1<=string<=50',
@@ -37,6 +38,7 @@ const getValidationSchema = (currentStep: SignUpStep) => {
         grade: 'number',
         joinedAt: 'number',
         getGradeAt: 'string | null',
+        birthday: '/^\\d{4}-\\d{2}-\\d{2}$/',
         legalAccepted: 'true',
       });
     default:
@@ -91,6 +93,7 @@ const createSignUpParams = (formValues: SignUpFormData) => ({
     grade: formValues.grade,
     joinedAt: formValues.joinedAt,
     getGradeAt: formValues.getGradeAt,
+    birthday: formValues.birthday,
   },
 });
 
@@ -157,6 +160,7 @@ export function useSignUpForm(currentYear: number) {
     grade: 0,
     joinedAt: currentYear,
     getGradeAt: null,
+    birthday: '',
     legalAccepted: false,
   });
 

--- a/apps/client/src/pages/Home.vue
+++ b/apps/client/src/pages/Home.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ActivityForm from '@/components/record/ActivityForm.vue';
+import { ArkErrors } from 'arktype';
 import hc from '@/lib/honoClient';
 import type { InferResponseType } from 'hono/client';
 import PracticeCountGraph from '@/components/home/PracticeCountGraph.vue';
@@ -7,6 +8,7 @@ import { queryKeys } from '@/lib/queryKeys';
 import RankingCard from '@/components/home/RankingCard.vue';
 import { Show } from '@clerk/vue';
 import { useAddActivity } from '@/composable/useActivity';
+import { AccountMetadata, isProfileComplete } from 'share';
 import { computed, ref } from 'vue';
 import { useQuery, useQueryClient } from '@tanstack/vue-query';
 
@@ -32,6 +34,13 @@ const { data: profileData } = useQuery({
     const res = await hc.user.clerk.profile.$get();
     if (!res.ok) throw new Error('Failed to fetch profile');
     const data = await res.json();
+    if (data.profile) {
+      const validated = AccountMetadata(data.profile);
+      if (validated instanceof ArkErrors) {
+        throw new TypeError('Invalid profile');
+      }
+      return { ...data, profile: validated } as ProfileResponse;
+    }
     return data as ProfileResponse;
   },
 });
@@ -51,7 +60,12 @@ const practiceData = computed(() => practiceDataRaw.value ?? null);
 const error = computed(() => (validationError.value ? '稽古データの取得に失敗しました' : null));
 const currentGrade = computed(() => {
   if (!profileData.value || !('profile' in profileData.value)) return 0;
-  return profileData.value.profile.grade ?? 0;
+  return profileData.value.profile?.grade ?? 0;
+});
+const needsProfileCompletion = computed(() => {
+  if (!profileData.value) return false;
+  if (!profileData.value.profile) return true;
+  return !isProfileComplete(profileData.value.profile);
 });
 const {
   data: rankingDataRaw,
@@ -141,6 +155,13 @@ const getNavLabelClass = (theme: string) => {
   <div class="max-w-7xl px-4 mx-auto">
     <Show when="signed-in">
       <div class="max-w-3xl gap-6 mx-auto flex flex-col">
+        <RouterLink
+          v-if="needsProfileCompletion"
+          to="/account"
+          class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 no-underline transition-colors hover:bg-amber-500/15">
+          プロフィール情報に未入力があります。誕生日を含む必要項目を登録してください。
+        </RouterLink>
+
         <div v-if="error" class="bg-red-50 text-red-500 p-4 rounded-lg text-sm dark:bg-red-900/10 text-center">
           {{ error }}
         </div>

--- a/apps/client/src/pages/admin/Accounts.vue
+++ b/apps/client/src/pages/admin/Accounts.vue
@@ -55,6 +55,7 @@
                 学年
                 <span v-if="sortBy === 'year'" class="ml-1">{{ sortOrder === 'asc' ? '↑' : '↓' }}</span>
               </th>
+              <th class="th-base md:px-6">誕生日</th>
             </tr>
           </thead>
           <tbody>
@@ -81,9 +82,12 @@
               <td class="td-base md:px-6 text-center">
                 <span class="text">{{ user.profile.yearLabel }}</span>
               </td>
+              <td class="td-base md:px-6 text-center">
+                <span class="text">{{ formatDateSlash(user.profile.birthday) }}</span>
+              </td>
             </tr>
             <tr v-if="sortedUsers.length === 0">
-              <td colspan="4" class="p-12 text-subtext text-center">ユーザーが見つかりませんでした</td>
+              <td colspan="5" class="p-12 text-subtext text-center">ユーザーが見つかりませんでした</td>
             </tr>
           </tbody>
         </table>
@@ -97,7 +101,7 @@ import AdminMenu from '@/components/admin/AdminMenu.vue';
 import hc from '@/lib/honoClient';
 import { queryKeys } from '@/lib/queryKeys';
 import { useQuery } from '@tanstack/vue-query';
-import { type AdminUserType, Role } from 'share';
+import { type AdminUserType, formatDateSlash, Role } from 'share';
 import { computed, ref } from 'vue';
 
 const searchQuery = ref('');

--- a/apps/client/src/pages/admin/UserDetail.vue
+++ b/apps/client/src/pages/admin/UserDetail.vue
@@ -40,7 +40,9 @@
                     <span class="sq-1 bg-subtext rounded-full" />
                     <span>{{ yearLabels[user.profile?.year as string] || user.profile?.year }}</span>
                     <span class="sq-1 bg-subtext rounded-full" />
-                    <span>{{ user.profile?.joinedAt }}年度入部</span>
+                    <span>{{ user.profile?.joinedAt ? `${user.profile.joinedAt}年度入部` : '入部年度未登録' }}</span>
+                    <span class="sq-1 bg-subtext rounded-full" />
+                    <span>誕生日: {{ formatDateSlash(user.profile?.birthday) }}</span>
                   </template>
                 </div>
               </div>
@@ -99,6 +101,7 @@
                 :min="1950"
                 :max="new Date().getFullYear() + 1" />
               <Input v-model="formData.getGradeAt" type="date" label="級段位取得日" />
+              <Input v-model="formData.birthday" type="date" label="誕生日" />
             </div>
 
             <div class="gap-2 mt-2 flex justify-end">
@@ -284,6 +287,7 @@
 
 <script setup lang="ts">
 import AdminMenu from '@/components/admin/AdminMenu.vue';
+import { formatDateSlash } from 'share';
 import hc from '@/lib/honoClient';
 import Input from '@/components/ui/UiInput.vue';
 import { queryKeys } from '@/lib/queryKeys';
@@ -377,8 +381,9 @@ const formData = ref({
   role: 'member',
   grade: 0,
   year: 'b1',
-  joinedAt: new Date().getFullYear(),
+  joinedAt: null as number | null,
   getGradeAt: '',
+  birthday: '',
 });
 const updateSuccess = ref('');
 const updateError = ref('');
@@ -399,16 +404,18 @@ watch(
         role: (newUser.profile.role as string) || 'member',
         grade: Number(newUser.profile.grade || 0),
         year: (newUser.profile.year as string) || 'b1',
-        joinedAt: Number(newUser.profile.joinedAt || new Date().getFullYear()),
+        joinedAt: newUser.profile.joinedAt ? Number(newUser.profile.joinedAt) : null,
         getGradeAt: newUser.profile.getGradeAt ? new Date(newUser.profile.getGradeAt).toISOString().split('T')[0]! : '',
+        birthday: newUser.profile.birthday ? new Date(newUser.profile.birthday).toISOString().split('T')[0]! : '',
       };
     } else {
       formData.value = {
         role: 'member',
         grade: 0,
         year: 'b1',
-        joinedAt: new Date().getFullYear(),
+        joinedAt: null,
         getGradeAt: '',
+        birthday: '',
       };
     }
   },
@@ -437,8 +444,9 @@ const { mutateAsync: updateProfile, isPending: updating } = useMutation({
     role: string;
     grade: number;
     year: string;
-    joinedAt: number;
+    joinedAt: number | null;
     getGradeAt: string | null;
+    birthday: string | null;
   }) => {
     const res = await hc.admin.users[':userId'].profile.$patch({
       param: { userId },
@@ -480,6 +488,7 @@ const handleUpdateProfile = async () => {
     year: formData.value.year,
     joinedAt: formData.value.joinedAt,
     getGradeAt: formData.value.getGradeAt ? formData.value.getGradeAt : null,
+    birthday: formData.value.birthday ? formData.value.birthday : null,
   };
 
   try {

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -16,10 +16,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "types": ["bun"],
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "baseUrl": "."
+    }
   },
-  "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"]
+  "include": ["src/**/*.ts", "src/**/*.vue", "test/**/*.ts", "env.d.ts"]
 }

--- a/apps/server/src/app/admin/helpers.ts
+++ b/apps/server/src/app/admin/helpers.ts
@@ -24,18 +24,20 @@ export const userActivitiesQuerySchema = type({
 
 export const adminProfileUpdateSchema = type({
   year: 'string',
-  grade: 'number',
+  grade: 'number | null',
   role: 'string',
-  joinedAt: 'number',
+  joinedAt: 'number | null',
   'getGradeAt?': 'string | null',
+  'birthday?': 'string | null',
 });
 
 export const publicMetadataProfileSchema = type({
   'role?': 'string',
-  'grade?': 'number | string',
-  'joinedAt?': 'number',
-  'year?': 'string',
+  'grade?': 'number | string | null',
+  'joinedAt?': 'number | null',
+  'year?': 'string | null',
   'getGradeAt?': 'string | null',
+  'birthday?': 'string | null',
 });
 
 // ============================================================
@@ -55,6 +57,7 @@ export function toAdminUser(user: User): AdminUserType {
   const yearStr = typeof meta?.year === 'string' ? meta.year : '';
   const joinedAt = typeof meta?.joinedAt === 'number' ? meta.joinedAt : null;
   const getGradeAt = typeof meta?.getGradeAt === 'string' ? meta.getGradeAt : null;
+  const birthday = typeof meta?.birthday === 'string' ? meta.birthday : null;
 
   const res = AdminUser({
     id: user.id,
@@ -71,6 +74,7 @@ export function toAdminUser(user: User): AdminUserType {
       yearLabel: translateYear(yearStr),
       joinedAt,
       getGradeAt,
+      birthday,
     },
   });
 

--- a/apps/server/src/app/admin/users.ts
+++ b/apps/server/src/app/admin/users.ts
@@ -47,6 +47,42 @@ const getMonthlyRanking = (env: Env) => {
     .limit(5);
 };
 
+function validateAdminJoinedAt(joinedAt: number | null) {
+  const currentYear = new Date().getFullYear();
+  const minJoinedAt = currentYear - 4;
+  const maxJoinedAt = currentYear + 1;
+
+  if (joinedAt !== null && (joinedAt < minJoinedAt || joinedAt > maxJoinedAt)) {
+    return `入部年度は${minJoinedAt}年から${maxJoinedAt}年の間で入力してください`;
+  }
+
+  return null;
+}
+
+async function resolveManagementRoles(clerkClient: ReturnType<typeof createClerkClient>, adminUserId: string, targetUserId: string) {
+  const adminUser = await clerkClient.users.getUser(adminUserId);
+  const adminProfileParse = helpers.publicMetadataProfileSchema(
+    helpers.coerceProfileMetadata(adminUser.publicMetadata)
+  );
+  const adminProfile = adminProfileParse instanceof type.errors ? null : adminProfileParse;
+  const adminRole = adminProfile?.role ? Role.fromString(adminProfile.role) : null;
+
+  const targetUser = await clerkClient.users.getUser(targetUserId);
+  const targetProfileParsed = helpers.publicMetadataProfileSchema(
+    helpers.coerceProfileMetadata(targetUser.publicMetadata)
+  );
+  const targetCurrentRole =
+    targetProfileParsed instanceof type.errors
+      ? Role.MEMBER
+      : (Role.fromString(targetProfileParsed.role ?? 'member') ?? Role.MEMBER);
+
+  return { adminRole, targetCurrentRole };
+}
+
+function normalizeOptionalDate(dateText: string | null | undefined) {
+  return dateText && dateText !== 'null' ? new Date(`${dateText}T00:00:00.000Z`) : null;
+}
+
 // ============================================================
 // Routes
 // ============================================================
@@ -134,43 +170,20 @@ const app = new Hono<{ Bindings: Env }>()
 
     const targetUserId = c.req.param('userId');
     const parsed = c.req.valid('json');
-    const { year, grade, role, joinedAt } = parsed;
+    const { year, grade, role, joinedAt, birthday } = parsed;
 
-    const currentYear = new Date().getFullYear();
-    const minJoinedAt = currentYear - 4;
-    const maxJoinedAt = currentYear + 1;
-    if (joinedAt < minJoinedAt || joinedAt > maxJoinedAt) {
-      return c.json(
-        {
-          error: `入部年度は${minJoinedAt}年から${maxJoinedAt}年の間で入力してください`,
-        },
-        400
-      );
-    }
+    const joinedAtError = validateAdminJoinedAt(joinedAt);
+    if (joinedAtError) return c.json({ error: joinedAtError }, 400);
 
     const clerkClient = createClerkClient({
       secretKey: c.env.CLERK_SECRET_KEY,
     });
 
-    const adminUser = await clerkClient.users.getUser(auth.userId);
-    const adminProfileParse = helpers.publicMetadataProfileSchema(
-      helpers.coerceProfileMetadata(adminUser.publicMetadata)
-    );
-    const adminProfile = adminProfileParse instanceof type.errors ? null : adminProfileParse;
-    const adminRole = adminProfile?.role ? Role.fromString(adminProfile.role) : null;
+    const { adminRole, targetCurrentRole } = await resolveManagementRoles(clerkClient, auth.userId, targetUserId);
 
     if (!adminRole?.isManagement()) {
       return c.json({ error: '権限が不足しています' }, 403);
     }
-
-    const targetUser = await clerkClient.users.getUser(targetUserId);
-    const targetProfileParsed = helpers.publicMetadataProfileSchema(
-      helpers.coerceProfileMetadata(targetUser.publicMetadata)
-    );
-    const targetCurrentRole =
-      targetProfileParsed instanceof type.errors
-        ? Role.MEMBER
-        : (Role.fromString(targetProfileParsed.role ?? 'member') ?? Role.MEMBER);
 
     if (targetCurrentRole && Role.compare(adminRole.role, targetCurrentRole.role) > 0) {
       return c.json({ error: '現在の権限より上書きできません' }, 403);
@@ -181,9 +194,14 @@ const app = new Hono<{ Bindings: Env }>()
       return c.json({ error: '権限が不足しています' }, 403);
     }
 
-    const normalizedGetGradeAt = parsed.getGradeAt && parsed.getGradeAt !== 'null' ? new Date(parsed.getGradeAt) : null;
-    if (normalizedGetGradeAt && isNaN(normalizedGetGradeAt.getTime())) {
+    const normalizedGetGradeAt = normalizeOptionalDate(parsed.getGradeAt);
+    if (normalizedGetGradeAt && Number.isNaN(normalizedGetGradeAt.getTime())) {
       return c.json({ error: '級段位取得日の形式が正しくありません' }, 400);
+    }
+
+    const normalizedBirthday = normalizeOptionalDate(birthday);
+    if (normalizedBirthday && Number.isNaN(normalizedBirthday.getTime())) {
+      return c.json({ error: '誕生日の形式が正しくありません' }, 400);
     }
 
     const updatedMetadata = {
@@ -191,6 +209,7 @@ const app = new Hono<{ Bindings: Env }>()
       getGradeAt: normalizedGetGradeAt ? helpers.formatDateToJSTString(normalizedGetGradeAt) : null,
       joinedAt,
       year,
+      birthday: normalizedBirthday ? helpers.formatDateToJSTString(normalizedBirthday) : null,
       role,
     };
 

--- a/apps/server/src/app/user/clerk.ts
+++ b/apps/server/src/app/user/clerk.ts
@@ -7,7 +7,7 @@ import { getAuth } from '@hono/clerk-auth';
 import { notify } from '../../lib/observability';
 import { getProfile, getUser, patchProfile } from '../../clerk/profile';
 
-import { AccountMetadata, Role, updateAccountSchema } from 'share';
+import { AccountMetadata, isProfileComplete, Role, updateAccountSchema } from 'share';
 
 export const clerk = new Hono<{ Bindings: Env }>() //
   .get('/account', async (c) => {
@@ -82,9 +82,17 @@ export const clerk = new Hono<{ Bindings: Env }>() //
 
     const profile = await getProfile(c);
 
-    if (!profile) return c.json({ error: 'Profile not found' }, 404);
+    if (!profile) {
+      return c.json(
+        {
+          profile: null,
+          needsProfileCompletion: true,
+        },
+        200
+      );
+    }
 
-    return c.json({ profile: { id: auth.userId, ...profile } }, 200);
+    return c.json({ profile: { id: auth.userId, ...profile }, needsProfileCompletion: !isProfileComplete(profile) }, 200);
   })
   .patch(
     '/profile',
@@ -98,10 +106,8 @@ export const clerk = new Hono<{ Bindings: Env }>() //
       const reqData = c.req.valid('json');
       const profile = await getProfile(c);
 
-      if (!profile) return c.json({ error: 'Profile not found' }, 404);
-
       const newUserData = await patchProfile(c, {
-        role: profile.role,
+        role: profile?.role ?? 'member',
         ...reqData,
       });
 
@@ -112,7 +118,13 @@ export const clerk = new Hono<{ Bindings: Env }>() //
 
       if (newProfile instanceof ArkErrors) return c.json({ error: 'Invalid profile data' }, 400);
 
-      return c.json({ profile: { id: newUserData.id, ...newProfile } }, 200);
+      return c.json(
+        {
+          profile: { id: newUserData.id, ...newProfile },
+          needsProfileCompletion: !isProfileComplete(newProfile),
+        },
+        200
+      );
     }
   )
   .get('/menu', async (c) => {

--- a/apps/server/src/app/webhooks/clerk.ts
+++ b/apps/server/src/app/webhooks/clerk.ts
@@ -46,6 +46,7 @@ async function handleUserCreated(event: ClerkWebhookEvent, c: Context): Promise<
         grade: meta.grade,
         joinedAt: meta.joinedAt,
         getGradeAt: meta.getGradeAt,
+        birthday: meta.birthday,
         role: 'member',
       },
     });

--- a/apps/server/src/clerk/profile.ts
+++ b/apps/server/src/clerk/profile.ts
@@ -4,9 +4,65 @@ import type { Context } from 'hono';
 import { createClerkClient } from '@clerk/backend';
 import { getAuth } from '@hono/clerk-auth';
 
-import { AccountMetadata } from 'share';
+import { AccountMetadata, type AccountMetadataType } from 'share';
 
 import { notify } from '../lib/observability';
+
+function normalizeRole(value: unknown): AccountMetadataType['role'] {
+  if (
+    value === 'admin' ||
+    value === 'captain' ||
+    value === 'vice-captain' ||
+    value === 'treasurer' ||
+    value === 'member'
+  ) {
+    return value;
+  }
+  return 'member';
+}
+
+function normalizeDateString(value: unknown): AccountMetadataType['getGradeAt'] {
+  if (value === null || value === '') return value;
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    return value as AccountMetadataType['getGradeAt'];
+  }
+  return null;
+}
+
+function normalizeYear(value: unknown): AccountMetadataType['year'] {
+  if (value === null || value === '') return value;
+  if (typeof value === 'string' && /^(b[1-4]|m[1-2]|d[1-2])$/u.test(value)) {
+    return value as AccountMetadataType['year'];
+  }
+  return '';
+}
+
+function normalizeProfileMetadata(metadata: Record<string, unknown> | null | undefined): AccountMetadataType {
+  const raw = metadata ?? {};
+
+  return {
+    role: normalizeRole(raw.role),
+    grade:
+      typeof raw.grade === 'number'
+        ? raw.grade
+        : typeof raw.grade === 'string'
+          ? Number.parseInt(raw.grade, 10)
+          : raw.grade === null
+            ? null
+            : null,
+    getGradeAt: normalizeDateString(raw.getGradeAt),
+    joinedAt:
+      typeof raw.joinedAt === 'number'
+        ? raw.joinedAt
+        : typeof raw.joinedAt === 'string'
+          ? Number.parseInt(raw.joinedAt, 10)
+          : raw.joinedAt === null
+            ? null
+            : null,
+    year: normalizeYear(raw.year),
+    birthday: normalizeDateString(raw.birthday),
+  };
+}
 
 export const getProfile = async (c: Context) => {
   const auth = getAuth(c);
@@ -15,8 +71,7 @@ export const getProfile = async (c: Context) => {
   const clerkClient = createClerkClient({ secretKey: c.env.CLERK_SECRET_KEY });
   const user = await clerkClient.users.getUser(auth.userId);
 
-  if (Object.keys(user.publicMetadata).length === 0) return null;
-  const profile = AccountMetadata(user.publicMetadata);
+  const profile = AccountMetadata(normalizeProfileMetadata(user.publicMetadata as Record<string, unknown> | undefined));
   if (profile instanceof ArkErrors) return null;
 
   return profile;

--- a/apps/server/test/clerk-webhook.test.ts
+++ b/apps/server/test/clerk-webhook.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const updateUserMock = mock(async () => {});
+const notifyMock = mock(() => {});
+
+mock.module('svix', () => ({
+  Webhook: class {
+    constructor(_secret: string) {}
+
+    verify(payload: string) {
+      return JSON.parse(payload);
+    }
+  },
+}));
+
+mock.module('@clerk/backend', () => ({
+  createClerkClient: () => ({
+    users: {
+      updateUser: updateUserMock,
+    },
+  }),
+}));
+
+mock.module('@/src/lib/observability', () => ({
+  notify: notifyMock,
+}));
+
+const { webhooks } = await import('@/src/app/webhooks/clerk');
+
+const testEnv = {
+  CLERK_SECRET_KEY: 'test-secret',
+  CLERK_WEBHOOK_SECRET: 'whsec_test',
+} as Env;
+
+describe('POST /clerk', () => {
+  beforeEach(() => {
+    updateUserMock.mockClear();
+    notifyMock.mockClear();
+  });
+
+  test('migrates birthday from unsafe metadata to public metadata on user.created', async () => {
+    const res = await webhooks.request(
+      'http://localhost/clerk',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'svix-id': '1',
+          'svix-timestamp': '1',
+          'svix-signature': 'test',
+        },
+        body: JSON.stringify({
+          type: 'user.created',
+          data: {
+            id: 'user_123',
+            unsafe_metadata: {
+              year: 'b1',
+              grade: 0,
+              joinedAt: 2024,
+              getGradeAt: null,
+              birthday: '2001-02-03',
+            },
+          },
+        }),
+      },
+      testEnv
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateUserMock).toHaveBeenCalledWith(
+      'user_123',
+      expect.objectContaining({
+        publicMetadata: expect.objectContaining({
+          birthday: '2001-02-03',
+        }),
+      })
+    );
+  });
+});

--- a/apps/server/test/user-profile.test.ts
+++ b/apps/server/test/user-profile.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const updateUserMetadataMock = mock(async (_userId: string, payload: Record<string, unknown>) => ({
+  id: 'member-user',
+  publicMetadata: payload.publicMetadata,
+}));
+
+const clerkUsers = {
+  getUser: mock(async (userId: string) => {
+    if (userId === 'member-user') {
+      return {
+        id: 'member-user',
+        publicMetadata: {
+          role: 'member',
+          grade: null,
+          getGradeAt: null,
+          joinedAt: null,
+          year: '',
+          birthday: '',
+        },
+      };
+    }
+
+    throw new Error('user not found');
+  }),
+  updateUserMetadata: updateUserMetadataMock,
+};
+
+mock.module('@hono/clerk-auth', () => ({
+  getAuth: () => ({
+    userId: 'member-user',
+    isAuthenticated: true,
+  }),
+}));
+
+mock.module('@clerk/backend', () => ({
+  createClerkClient: () => ({
+    users: clerkUsers,
+  }),
+}));
+
+mock.module('@/src/lib/observability', () => ({
+  notify: mock(() => {}),
+}));
+
+const { clerk } = await import('@/src/app/user/clerk');
+
+const testEnv = {
+  CLERK_SECRET_KEY: 'test-secret',
+} as Env;
+
+describe('GET /profile', () => {
+  beforeEach(() => {
+    clerkUsers.getUser.mockClear();
+  });
+
+  test('returns editable incomplete profile instead of 404', async () => {
+    const res = await clerk.request('http://localhost/profile', {}, testEnv);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toMatchObject({
+      needsProfileCompletion: true,
+      profile: {
+        id: 'member-user',
+        role: 'member',
+        grade: null,
+        joinedAt: null,
+        year: '',
+        birthday: '',
+      },
+    });
+  });
+});
+
+describe('PATCH /profile', () => {
+  beforeEach(() => {
+    clerkUsers.getUser.mockClear();
+    updateUserMetadataMock.mockClear();
+  });
+
+  test('updates birthday on profile payload', async () => {
+    const res = await clerk.request(
+      'http://localhost/profile',
+      {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          grade: 0,
+          getGradeAt: null,
+          joinedAt: 2024,
+          year: 'b1',
+          birthday: '2001-02-03',
+        }),
+      },
+      testEnv
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(updateUserMetadataMock).toHaveBeenCalledWith(
+      'member-user',
+      expect.objectContaining({
+        publicMetadata: expect.objectContaining({
+          birthday: '2001-02-03',
+        }),
+      })
+    );
+    expect(json).toMatchObject({
+      needsProfileCompletion: false,
+      profile: {
+        id: 'member-user',
+        birthday: '2001-02-03',
+      },
+    });
+  });
+});

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -16,8 +16,7 @@
     "paths": {
       "@/*": ["./*"]
     },
-    "types": ["node", "./env.d.ts"],
-    "baseUrl": "."
+    "types": ["bun", "node", "./env.d.ts"]
   },
-  "include": ["src/**/*.ts", "env.d.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "env.d.ts"]
 }

--- a/apps/share/index.ts
+++ b/apps/share/index.ts
@@ -1,4 +1,4 @@
-export { AccountMetadata, AccountInfo } from './src/account';
+export { AccountMetadata, AccountInfo, formatDateSlash, isProfileComplete, type AccountMetadataType } from './src/account';
 
 export { AdminUser, type AdminUserType } from './src/admin';
 

--- a/apps/share/src/account.ts
+++ b/apps/share/src/account.ts
@@ -3,10 +3,11 @@ import { type } from 'arktype';
 
 export const AccountMetadata = type({
   role: Role.type,
-  grade: '(string.numeric.parse |> -5 <= number.integer <= 5) | -5 <= number.integer <= 5',
+  grade: '((string.numeric.parse |> -5 <= number.integer <= 5) | -5 <= number.integer <= 5) | null',
   getGradeAt: "/^\\d{4}-\\d{2}-\\d{2}$/ | null | ''",
-  joinedAt: '(string.numeric.parse |> 2020 <= number.integer <= 9999) | 2020 <= number.integer <= 9999',
-  year: '/^(b[1-4]|m[1-2]|d[1-2])$/',
+  joinedAt: '((string.numeric.parse |> 2020 <= number.integer <= 9999) | 2020 <= number.integer <= 9999) | null',
+  year: '/^(b[1-4]|m[1-2]|d[1-2])$/ | null | ""',
+  birthday: "/^\\d{4}-\\d{2}-\\d{2}$/ | null | ''",
   '+': 'delete',
 });
 
@@ -16,3 +17,23 @@ export const AccountInfo = type({
   username: '(string | undefined)?',
   profileImage: '(unknown)?',
 });
+
+export type AccountMetadataType = typeof AccountMetadata.infer;
+
+export function isProfileComplete(profile: AccountMetadataType | null | undefined): boolean {
+  if (!profile) return false;
+
+  return (
+    typeof profile.grade === 'number' &&
+    typeof profile.joinedAt === 'number' &&
+    typeof profile.year === 'string' &&
+    profile.year.length > 0 &&
+    typeof profile.birthday === 'string' &&
+    profile.birthday.length > 0
+  );
+}
+
+export function formatDateSlash(value: string | null | undefined): string {
+  if (!value) return '-';
+  return value.split('-').join('/');
+}

--- a/apps/share/src/admin.ts
+++ b/apps/share/src/admin.ts
@@ -19,6 +19,7 @@ export const AdminUser = type({
     yearLabel: 'string',
     joinedAt: 'number | null',
     getGradeAt: 'string | null',
+    birthday: 'string | null',
   }),
 });
 

--- a/apps/share/src/records.ts
+++ b/apps/share/src/records.ts
@@ -1,7 +1,7 @@
 import { type } from 'arktype';
 
 function isStrictIsoDate(value: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
     return false;
   }
 
@@ -19,13 +19,13 @@ function isStrictIsoDate(value: string): boolean {
 }
 
 export const recordQuerySchema = type({
-  'userId?': /^user_[\w]{27}$/,
-  'startDate?': /^\d{4}-\d{2}-\d{2}$/,
-  'endDate?': /^\d{4}-\d{2}-\d{2}$/,
+  'userId?': /^user_[\w]{27}$/u,
+  'startDate?': /^\d{4}-\d{2}-\d{2}$/u,
+  'endDate?': /^\d{4}-\d{2}-\d{2}$/u,
 });
 
 export const createActivitySchema = type({
-  date: /^\d{4}-\d{2}-\d{2}$/,
+  date: /^\d{4}-\d{2}-\d{2}$/u,
   period: 'number > 0',
 }).narrow((input) => isStrictIsoDate(input.date));
 

--- a/apps/share/test/account.test.ts
+++ b/apps/share/test/account.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { ArkErrors } from 'arktype';
-import { AccountMetadata, AccountInfo } from '../index';
+import { AccountMetadata, AccountInfo, formatDateSlash, isProfileComplete } from '../index';
 
 function isValid(result: unknown): boolean {
   return !(result instanceof ArkErrors);
@@ -14,6 +14,7 @@ describe('AccountMetadata', () => {
       getGradeAt: '2024-01-01',
       joinedAt: 2024,
       year: 'b1',
+      birthday: '2001-02-03',
     });
     expect(isValid(result)).toBe(true);
   });
@@ -25,66 +26,103 @@ describe('AccountMetadata', () => {
       getGradeAt: null,
       joinedAt: '2024',
       year: 'm1',
+      birthday: '2001-02-03',
     });
     expect(isValid(result)).toBe(true);
   });
 
   test('should accept valid numeric grade within range', () => {
-    expect(isValid(AccountMetadata({ role: 'member', grade: -5, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: -5, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 5, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 5, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: '' }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(
+        AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: '2001-02-03' })
+      )
+    ).toBe(
       true
     );
   });
 
   test('should accept valid year formats', () => {
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b4' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b4', birthday: null }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'm1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'm1', birthday: null }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'm2' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'm2', birthday: null }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'd1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'd1', birthday: null }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'd2' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'd2', birthday: null }))
+    ).toBe(
       true
     );
   });
 
   test('should accept valid roles', () => {
-    expect(isValid(AccountMetadata({ role: 'admin', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
-      true
-    );
-    expect(isValid(AccountMetadata({ role: 'captain', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'admin', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       true
     );
     expect(
-      isValid(AccountMetadata({ role: 'vice-captain', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))
+      isValid(
+        AccountMetadata({ role: 'captain', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null })
+      )
+    ).toBe(
+      true
+    );
+    expect(
+      isValid(
+        AccountMetadata({ role: 'vice-captain', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null })
+      )
     ).toBe(true);
     expect(
-      isValid(AccountMetadata({ role: 'treasurer', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))
+      isValid(
+        AccountMetadata({ role: 'treasurer', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null })
+      )
     ).toBe(true);
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       true
     );
   });
 
   test('should accept getGradeAt as null or empty string', () => {
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       true
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: '', joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 0, getGradeAt: '', joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       true
     );
   });
@@ -96,8 +134,33 @@ describe('AccountMetadata', () => {
       getGradeAt: '2024-06-15',
       joinedAt: 2024,
       year: 'b1',
+      birthday: '2001-02-03',
     });
     expect(isValid(result)).toBe(true);
+  });
+
+  test('should accept missing birthday and missing profile fields for existing users', () => {
+    const result = AccountMetadata({
+      role: 'member',
+      grade: null,
+      getGradeAt: null,
+      joinedAt: null,
+      year: '',
+      birthday: '',
+    });
+    expect(isValid(result)).toBe(true);
+  });
+
+  test('should reject invalid birthday format', () => {
+    const result = AccountMetadata({
+      role: 'member',
+      grade: 0,
+      getGradeAt: null,
+      joinedAt: 2024,
+      year: 'b1',
+      birthday: '2001/02/03',
+    });
+    expect(isValid(result)).toBe(false);
   });
 
   test('should reject invalid role', () => {
@@ -107,6 +170,7 @@ describe('AccountMetadata', () => {
       getGradeAt: null,
       joinedAt: 2024,
       year: 'b1',
+      birthday: null,
     });
     expect(isValid(result)).toBe(false);
   });
@@ -118,6 +182,7 @@ describe('AccountMetadata', () => {
       getGradeAt: null,
       joinedAt: 2024,
       year: 'x5',
+      birthday: null,
     });
     expect(isValid(result)).toBe(false);
   });
@@ -129,17 +194,55 @@ describe('AccountMetadata', () => {
       getGradeAt: null,
       joinedAt: 2019,
       year: 'b1',
+      birthday: null,
     });
     expect(isValid(result)).toBe(false);
   });
 
   test('should reject grade out of range', () => {
-    expect(isValid(AccountMetadata({ role: 'member', grade: 6, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: 6, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       false
     );
-    expect(isValid(AccountMetadata({ role: 'member', grade: -6, getGradeAt: null, joinedAt: 2024, year: 'b1' }))).toBe(
+    expect(
+      isValid(AccountMetadata({ role: 'member', grade: -6, getGradeAt: null, joinedAt: 2024, year: 'b1', birthday: null }))
+    ).toBe(
       false
     );
+  });
+});
+
+describe('profile helpers', () => {
+  test('isProfileComplete returns true when required fields exist', () => {
+    expect(
+      isProfileComplete({
+        role: 'member',
+        grade: 0,
+        getGradeAt: null,
+        joinedAt: 2024,
+        year: 'b1',
+        birthday: '2001-02-03',
+      })
+    ).toBe(true);
+  });
+
+  test('isProfileComplete returns false when birthday is missing', () => {
+    expect(
+      isProfileComplete({
+        role: 'member',
+        grade: 0,
+        getGradeAt: null,
+        joinedAt: 2024,
+        year: 'b1',
+        birthday: '',
+      })
+    ).toBe(false);
+  });
+
+  test('formatDateSlash converts profile dates for display', () => {
+    expect(formatDateSlash('2001-02-03')).toBe('2001/02/03');
+    expect(formatDateSlash(null)).toBe('-');
   });
 });
 

--- a/apps/share/test/admin.test.ts
+++ b/apps/share/test/admin.test.ts
@@ -23,6 +23,7 @@ describe('AdminUser', () => {
         yearLabel: '1回生',
         joinedAt: 2024,
         getGradeAt: '2024-01-01',
+        birthday: '2001-02-03',
       },
     });
     expect(isValid(result)).toBe(true);
@@ -44,6 +45,7 @@ describe('AdminUser', () => {
         yearLabel: '1回生',
         joinedAt: null,
         getGradeAt: null,
+        birthday: null,
       },
     });
     expect(isValid(result)).toBe(true);
@@ -64,6 +66,7 @@ describe('AdminUser', () => {
         yearLabel: '1回生',
         joinedAt: 2024,
         getGradeAt: '2024-01-01',
+        birthday: '2001-02-03',
       },
     });
     expect(isValid(result)).toBe(false);
@@ -96,6 +99,7 @@ describe('AdminUser', () => {
         yearLabel: '1回生',
         joinedAt: '2024',
         getGradeAt: '2024-01-01',
+        birthday: '2001-02-03',
       },
     });
     expect(isValid(result)).toBe(false);
@@ -117,6 +121,7 @@ describe('AdminUser', () => {
         yearLabel: '1回生',
         joinedAt: 2024,
         getGradeAt: '2024-01-01',
+        birthday: '2001-02-03',
       },
     });
     expect(isValid(result)).toBe(false);
@@ -138,6 +143,7 @@ describe('AdminUser', () => {
         yearLabel: '1回生',
         joinedAt: 2024,
         getGradeAt: '2024-01-01',
+        birthday: '2001-02-03',
       },
     });
     expect(isValid(result)).toBe(false);

--- a/apps/share/tsconfig.json
+++ b/apps/share/tsconfig.json
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": "."
+    "types": ["bun"]
   },
-  "include": ["index.ts", "src/**/*.ts"]
+  "include": ["index.ts", "src/**/*.ts", "test/**/*.ts"]
 }

--- a/apps/share/tsconfig.test.json
+++ b/apps/share/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["bun"]
+    "types": ["types/bun"]
   },
   "include": ["index.ts", "src/**/*.ts", "test/**/*.ts"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "record",
       "devDependencies": {
+        "@types/bun": "1.3.14",
         "knip": "6.16.1",
         "oxfmt": "0.55.0",
         "oxlint": "1.70.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
+    "@types/bun": "1.3.14",
     "knip": "6.16.1",
     "oxfmt": "0.55.0",
     "oxlint": "1.70.0",


### PR DESCRIPTION
## Summary
- Add shared account, admin, and record types/validation in `apps/share`
- Wire Clerk profile sync and webhook handling on the server
- Update client signup, home, profile, and admin account views to use the new flow
- Add server and shared tests covering profile and webhook behavior

## Testing
- Added unit and integration coverage for shared account rules, admin helpers, user profile handling, and Clerk webhooks
- Client-side validation and page updates were adjusted to match the new profile data flow